### PR TITLE
Fix js error and add paragraph margins for output

### DIFF
--- a/script.js
+++ b/script.js
@@ -47,6 +47,9 @@ document.addEventListener("DOMContentLoaded", function() {
     };
 
     function getSentenceFromParagraph(p) {
+      if (p === '') {
+        return [];
+      }
       // Find sentences and account for edge cases where they end in more than one punctuation mark or in quotes or parenthetical
       // Regex pattern from James at https://stackoverflow.com/a/72280712/479663
       let sentences = p

--- a/style.css
+++ b/style.css
@@ -331,6 +331,10 @@ label {
   position: relative;
 }
 
+.display__output p {
+  margin-bottom: var(--sp__spacer-sm);
+}
+
 .counters {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
Fixes a js error when there is an empty paragraph or extra carriage return in the input. Also adds some margin around paragraphs in the output so you can visibly see those line breaks.